### PR TITLE
Ignore the information about the release year...

### DIFF
--- a/TrackInfo.pm
+++ b/TrackInfo.pm
@@ -215,6 +215,9 @@ sub _fetchLyrics {
 	# specific rule for the "[E]"xplicit flag - it's too specific/short to fit in with the above
 	$args->{title} =~ s/\[E\]//g;
 
+	# remove trailing release year information
+	$args->{title} =~ s/ \(([0-9]{1,4}(\*+)?|\+NEU\+)\)$//;
+
 	# remove trailing non-word characters
 	$args->{title} =~ s/[\s\W]{2,}$//;
 	$args->{title} =~ s/\s*$//;


### PR DESCRIPTION
within the title to capture lyrics.

This fixes missing lyrics on some German radio stations.